### PR TITLE
Rewritev2.2

### DIFF
--- a/Interpreter/AST.cpp
+++ b/Interpreter/AST.cpp
@@ -476,13 +476,15 @@ namespace dust {
 				   buf + "+- " + node_type + "::catch\n" + catch_code->printString(buf + " ");
 		}
 		void TryCatch::addChild(std::shared_ptr<ASTNode>& c) {
-			auto& code_block = catch_code ? try_code : catch_code;
+			auto& code_block = try_code ? catch_code : try_code;
 			if (code_block) throw error::operands_error{ "Attempt to add more than two blocks to TryCatch node" };
 
 			code_block.swap(c);
 			if (!code_block) throw error::invalid_ast_construction{ "Attempt to construct TryCatch node with a non-Block node" };
 		}
-
+		bool TryCatch::isFull() {
+			return try_code && catch_code;
+		}
 
 		std::string ASTNode::node_type = "ASTNode";
 		std::string Debug::node_type = "Debug";

--- a/Interpreter/AST.cpp
+++ b/Interpreter/AST.cpp
@@ -48,7 +48,7 @@ namespace dust {
 				e.push(std::stod(val));
 
 			else if (id == type::Traits<bool>::id)
-				e.push<bool>(std::stoi(val));
+				e.push(val == "true");
 
 			else if (id == type::Traits<std::string>::id)
 				e.push(val);

--- a/Interpreter/AST.h
+++ b/Interpreter/AST.h
@@ -355,6 +355,11 @@ namespace dust {
 		return std::make_shared<R>(std::forward<std::shared_ptr<T>>(ptr));
 	}
 
+	template <class T>
+	bool isNode(std::shared_ptr<parse::ASTNode>& p) {
+		return std::dynamic_pointer_cast<T>(p) != nullptr;
+	}
+
 	template <class ostream>
 	void printAST(ostream& s, std::shared_ptr<parse::ASTNode>& ast) {
 		(s << ast->printString("|")).flush();

--- a/Interpreter/AST.h
+++ b/Interpreter/AST.h
@@ -340,6 +340,8 @@ namespace dust {
 				virtual std::string printString(std::string buf);
 
 				virtual void addChild(std::shared_ptr<ASTNode>& c);
+
+				bool isFull();
 		};
 
 		template<class T> std::string List<T>::node_type = "List<" + T::node_type + ">";

--- a/Interpreter/Actions.h
+++ b/Interpreter/Actions.h
@@ -50,7 +50,7 @@ namespace dust {
 					do block->addChild(ast.at());
 					while (!isNode<Control>(ast.pop()));
 
-					// Try-Catch reduction (need to generalize for If-Then-Else and functions)
+					// Try-Catch reduction (need to generalize for If-Elseif-Else and functions)
 					if (!ast.empty() && isNode<TryCatch>(ast.at()) && !std::dynamic_pointer_cast<TryCatch>(ast.at())->isFull())
 						ast.at()->addChild(block);
 					else
@@ -128,7 +128,7 @@ namespace dust {
 				// stack : ..., {TryCatch}
 
 				if (!isNode<TryCatch>(ast.at()))
-					throw error::missing_node_x{ "TryCatch" };			// Need to improve error messages
+					throw error::missing_node_x{ "Catch", "TryCatch" };
 
 				action<scope>::push(ast, 1, in);
 				lvl.push(lvl.at() + 1);

--- a/Interpreter/Actions.h
+++ b/Interpreter/Actions.h
@@ -53,18 +53,31 @@ namespace dust {
 
 		template <> struct action<file> {
 			static void apply(input& in, AST& ast, ScopeTracker& lvl) {
-				// Finish assembly of AST (Possibly wrong when requiring files)
-				action<scope>::reduce(ast, lvl.at() + 1);
-				lvl.clear();			// I could always use a unique ScopeTracker for each file
+				// stack: ... | ..., {Control}, ....
 
-										// stack: ..., {Block}
+				// Finish assembly of AST
+				if (ast.empty()) {
+					auto b = makeNode<Block>();
+					b->addChild(makeNode<Control>());
+					ast.push(b);
+
+				} else {
+					// Possibly wrong when requiring files (clears the scopetracker)
+					action<scope>::reduce(ast, lvl.at() + 1);
+					lvl.clear();			// I could always use a unique ScopeTracker for each file
+
+				}
+
+				setFields(ast);
+			}
+
+			static void setFields(AST& ast) {
+				// stack: ..., {Block}
 
 				auto b = std::dynamic_pointer_cast<Block>(ast.at());
 
 				b->excep_if_empty = false;
 				// require code
-
-				// stack: ..., {Block}
 			}
 		};
 

--- a/Interpreter/Control.h
+++ b/Interpreter/Control.h
@@ -5,6 +5,23 @@
 namespace dust {
 	namespace parse {
 
+		//template <typename Rule, typename Input, typename... States>
+		//void success(const Input& in, States&&... ss) {
+			//normal<Rule>::success(in, ss...);
+		//}
+
+		//template <typename Input, typename... States>
+		//void success<bad_decimal>(const Input& in, States&&... ss) {
+			//normal<bad_decimal>::raise(in, ss...);
+		//}
+
+		// Variable templates not yet supported
+		//template <typename Rule>
+		//static const auto success = normal<Rule>::success;
+
+		//template <>
+		//static const auto success<bad_decimal> = normal<bad_decimal>::raise;
+
 		template <typename Rule>
 		struct control : normal<Rule> {
 			// Called before attempting to match Rule
@@ -17,6 +34,7 @@ namespace dust {
 			template <typename Input, typename... States>
 			static void success(const Input& in, States&&... ss) {
 				normal<Rule>::start(in, ss...);
+				//success<Rule>(in, ss...);
 			}
 
 			// Called if Rule failed (input not consumed)
@@ -38,6 +56,42 @@ namespace dust {
 				return normal<Rule>::template match<A, Action, Control>(in, ss...);
 			}
 		};
+
+		//*/
+		template <> struct control<bad_decimal> {
+			// Called before attempting to match Rule
+			template <typename Input, typename... States>
+			static void start(const Input& in, States&&... ss) {
+				normal<bad_decimal>::start(in, ss...);
+			}
+
+			// Called if Rule succeeded (input was consumed)
+			template <typename Input, typename... States>
+			static void success(const Input& in, States&&... ss) {
+				normal<bad_decimal>::raise(in, ss...);
+			}
+
+			// Called if Rule failed (input not consumed)
+			template <typename Input, typename... States>
+			static void failure(const Input& in, States&&... ss) {
+				normal<bad_decimal>::start(in, ss...);
+			}
+
+			// Called to raise an exception (for must<Rule>)
+			template <typename Input, typename... States>
+			static void raise(const Input& in, States&&... ss) {
+				normal<bad_decimal>::raise(in, ss...);
+			}
+
+			// Called before Rule::match (can make some changes here)
+			template <apply_mode A, template <typename...> class Action,
+				template <typename...> class Control, typename Input, typename... States>
+			static bool match(Input& in, States&&... ss) {
+				return normal<bad_decimal>::template match<A, Action, Control>(in, ss...);
+			}
+
+		};
+		//*/
 
 	}
 }

--- a/Interpreter/Exceptions/parsing.h
+++ b/Interpreter/Exceptions/parsing.h
@@ -28,7 +28,9 @@ namespace dust {
 		class missing_node_x : public parse_error {
 			public:
 				missing_node_x(const std::string& _n)
-					: parse_error{ "Attempt to construct " + _n + " node without a empty " + _n + " node" } {}
+					: missing_node_x{ _n, _n } {}
+				missing_node_x(const std::string& _n, const std::string& _nd)
+					: parse_error{ "Attempt to construct " + _n + " node without a " + _nd + " node" } {}
 				~missing_node_x() throw() {}
 		};
 

--- a/Interpreter/Grammar.h
+++ b/Interpreter/Grammar.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <pegtl.hh>
 #include "ast.h"
 
 #define pstring(x) pegtl_string_t(x)

--- a/Interpreter/Grammar.h
+++ b/Interpreter/Grammar.h
@@ -93,7 +93,6 @@ namespace dust {
 		struct table : seq<o_brack, seps, table_inner> {};								// \[ *{expr}* *\]
 
 		struct literals : sor<decimal, bad_decimal, integer, boolean, table, str, k_nil> {};
-		//struct literals : sor<decimal, integer, boolean, table, str, k_nil> {};
 
 
 		// Operators
@@ -175,13 +174,13 @@ namespace dust {
 		// Organization Tokens
 		// line = \t*[ ]*{expr}? *{comment}?\n
 
-		struct line : seq<scope, pad<expr, tail>, opt<comment>, must<eolf>> {};		// fails on empty lines
-		//struct line : must<scope, sor<pad<expr, tail>, star<tail>>, opt<comment>, eolf> {};
-		//struct line : sor<seq<scope, pad<expr, tail>, opt<comment>, must<eolf>>, seq<star<tail>, opt<comment>, must<eolf>>> {};
-		//struct line : seq<scope, pad<opt<expr>, tail>, opt<comment>, must<eolf>> {};
+		// This is slow (Has to parse over eval_line twice on match)
+		struct eval_line : seq<scope, pad<expr, tail>, sor<comment, must<eolf>>> {};				// Analysis says...
+		struct line : if_then_else<at<eval_line>, eval_line, until<eolf>> {};						// No progress (but it works)
+		//struct line : seq<scope, pad<expr, tail>, sor<comment, must<eolf>>> {};					// Progress	   (but doesn't work)
 
-		struct file : star<line> {};			// Progress, but doesn't work
-		//struct file : star<sor<line, until<eolf>>> {};			    // No progress, but works
+		struct file : star<line> {};
+		//struct file : star<if_then_else<at<line>, line, until<eolf>>> {};
 	}
 
 	struct grammar : pegtl::must<parse::file> {};

--- a/Interpreter/Grammar.h
+++ b/Interpreter/Grammar.h
@@ -160,13 +160,15 @@ namespace dust {
 		struct expr_type : sor<ee_type, expr_7> {};										// type[ ]*{type_id} *{table}( *<- *{type_id})?
 
 		// Try-Catch
-		// struct ee_try : seq<seps, expr> {};
-		// struct ee_catch : seq<one<'('>, var_id, one<')'>, seps, expr> {};
-		// struct ee_trycatch : if_must<k_try, ee_try, seps, k_catch, ee_catch> {};
-		// struct expr_trycatch : sor<ee_trycatch, expr_type> {};
-		struct expr_trycatch : expr_type {};				// unimplemented
+		struct inline_expr : seq<plus<tail>, expr> {};
 
+		struct ee_try : if_must<k_try, opt<inline_expr>> {};
+		struct ee_catch : if_must<k_catch, seps, one<'('>, var_id, one<')'>, opt<inline_expr>> {};
+		// ee_catch isn't being matched
 
+		struct expr_trycatch : sor<ee_try, ee_catch, expr_type> {};
+
+		// Collector Tags
 		struct expr_x : expr_trycatch {};
 		struct expr : expr_x {};
 

--- a/Interpreter/Grammar.h
+++ b/Interpreter/Grammar.h
@@ -1,9 +1,7 @@
 #pragma once
 
 #include <pegtl.hh>
-#include "AST.h"
-
-// For quick testing of grammar, pegjs.org/online
+#include "ast.h"
 
 #define pstring(x) pegtl_string_t(x)
 #define key_string(x) key<pstring(x)> {}
@@ -12,34 +10,44 @@ namespace dust {
 	namespace parse {
 		using namespace pegtl;
 		using AST = Stack<std::shared_ptr<ASTNode>>;
+		using eps = success;
 
 		// Rule Templates
 		template <typename Rule, typename Sep, typename Pad>							// Covers pegtl::list (apes list_tail)
 		struct list : seq<pegtl::list<Rule, Sep, Pad>, opt<star<Pad>, disable<Sep>>> {};	// Prevents the comma action from being called multiple times (is this necessary?)
 		template <typename Rule>
 		struct unless : if_then_else<at<Rule>, failure, any> {};
+		template <typename Cond, typename Then>
+		struct _if : if_then_else<Cond, Then, eps> {};
 
 
-		// Forward declarations
-		struct expr;	struct expr_0;			struct expr_x;
-		struct block;	struct inline_block;	struct expr_7;
-		struct comma;	struct sep;				struct keywords;
+		// Forward Declarations
+		struct expr;		struct expr_0;		struct expr_x;
+		struct keywords;	struct expr_7;
 
 
-		// "Readability" Tokens
+		// Whitespace 
+		//struct space : one<' ', '\n', '\r', \t', '\v', '\f'> {};
+		struct spaces : plus<one<' '>> {};
+		struct seps : star<space> {};
+		struct white : plus<space> {};
+		struct scope : star<one<'\t'>> {};
+		struct tail : one<' ', '\r', '\t', '\v', '\f'> {};
+		struct endline : until<eolf, space> {};
+
+
+		// Readability Tokens
+		struct comma : one<','> {};
+
 		template <typename Rule>
-		struct w_list : list<Rule, comma, sep> {};										// Weak list, allows trailing comma		// I could add the Sep template and pass in comma everywhere (arguably more extensible, don't need the forward declaration) or I could just move these after "Readability"
+		struct w_list : list<Rule, comma, space> {};									// Weak list, allows trailing comma		// I could add the Sep template and pass in comma everywhere (arguably more extensible, don't need the forward declaration) or I could just move these after "Readability"
 		template <typename Rule>
-		struct s_list : pegtl::list<Rule, comma, sep> {};								// Strict list, no trailing comma
+		struct s_list : pegtl::list<Rule, comma, space> {};								// Strict list, no trailing comma
 
-		struct sep : one<' ', '\n'> {};
-		//struct sep : one<' ', '\n', '\t'> {};
-		struct seps : star<sep> {};
 		struct o_paren : one<'('> {};
 		struct c_paren : one<')'> {};
 		struct o_brack : one<'['> {};
 		struct c_brack : one<']'> {};
-		struct comma : one<','> {};
 		struct quote : one<'"'> {};
 		struct esc : one<'\\'> {};		// % ???
 		struct comment : if_must<two<'#'>, until<eolf>> {};								// ##.*
@@ -50,7 +58,7 @@ namespace dust {
 		// Identifier Tokens
 		struct id_end : identifier_other {};
 		struct type_id : seq<range<'A', 'Z'>, star<id_end>> {};							// [A-Z]{id_end}*
-		struct var_id : seq<not_at<keywords>, range<'a', 'z'>, star<id_end>> {};		// [a-z]{id_end}*
+		struct var_id : seq<not_at<keywords>, range<'a', 'z'>, star<id_end>> {};			// [a-z]{id_end}*
 		struct var_lookup : seq<star<one<'.'>>, at<var_id>> {};
 		struct var_name : seq<var_lookup, var_id> {};									// \.*{var_id}
 
@@ -59,7 +67,6 @@ namespace dust {
 		template <class Str>
 		struct key : seq<Str, not_at<id_end>> {};
 
-		// This doesn't actually prevent the keywords from becoming variables
 		struct k_and : key_string("and");
 		struct k_true : key_string("true");
 		struct k_false : key_string("false");
@@ -70,7 +77,7 @@ namespace dust {
 		struct k_type : key_string("type");
 		struct k_try : key_string("try");
 		struct k_catch : key_string("catch");
-		struct k_inherit : pstring("<-") {};											// Can't start an indentifier
+
 		struct keywords : sor<k_and, k_true, k_false, k_or, k_nil, k_do, k_if, k_type, k_try, k_catch> {};
 
 
@@ -80,140 +87,100 @@ namespace dust {
 		struct boolean : sor<k_true, k_false> {};
 		struct body : star<sor<seq<esc, quote>, unless<quote>>> {};						// ((\\\")|[^"])*
 		struct str : seq<quote, body, quote> {};										// \"{body}\"
-		struct table_inner : until<c_brack, expr> {};									// NOTE: THIS GRAMMAR DOESN'T ALLOW FOR TABLES TO BE DECLARED ON MULTIPLE LINES (with indentation)
-		struct table : seq<o_brack, seps, table_inner> {};								// \[ *{expr}*]
+
+		struct table_inner : until<c_brack, sor<white, expr>> {};
+		struct table : seq<o_brack, seps, table_inner> {};								// \[ *{expr}* *\]
+
 		struct literals : sor<decimal, integer, boolean, table, str, k_nil> {};
 
 
-		// Operator Tokens
+		// Operators
 		struct op_0 : one<'!', '-'> {};																	// unary operators
 		struct op_1 : one<'^'> {};
 		struct op_2 : one<'*', '/'> {};
 		struct op_3 : one<'+', '-', '%'> {};
 		struct op_4 : sor<pstring("<="), pstring(">="), pstring("!="), one<'<', '=', '>'>> {};			// A tad "crude"
-		struct op_x : seq<one<':'>, opt<one<'^', '*', '/', '+', '-', '%', '<', '=', '>'>>> {};			// Assignment operators (should :>=, :<=, and :!= be valid???)
+		struct op_7 : seq<one<':'>, opt<one<'^', '*', '/', '+', '-', '%', '<', '=', '>'>>> {};			// Assignment operators (should :>=, :<=, and :!= be valid???)
+		struct op_inherit : pstring("<-") {};
 
 
 		// Atomic Tokens
 		struct unary : seq<op_0, expr_0> {};
+		struct cast : seq<one<'('>, type_id, one<')'>> {};								// to avoid matching parens (error?)S
 		struct parens : if_must<o_paren, seps, expr, seps, c_paren> {};					// \( *{expr} *\)
-		struct cast : seq<one<'('>, type_id, one<')'>> {};								// Cast is an Atomic to avoid errors with matching parens (rework ?)
 		struct lvalue : sor<literals, var_name, unary, cast, parens> {};				// {number}|{var_name}|{unary}|{parens}
 
 
 		// Expression Tokens
-
-		// Possible "indexable" grammar
+		// Indexable variables/values
 		struct dot_index : seq<one<'.'>, sor<var_id, integer>> {};
 		struct brac_index : seq<one<'['>, seps, expr_7, seps, one<']'>> {};				// will need to update if I add a layer above expr_7
-		struct expr_0 : seq<lvalue, star<sor<dot_index, brac_index>>> {};				// {lvalue}(\.({var_id}|{integer})|\[{expr_7}\])*
+		struct expr_0 : seq<lvalue, star<sor<dot_index, brac_index>>> {}; 				// {lvalue}(\.({var_id}|{integer})|\[{expr_7}\])*
 
-		// Type Casting
-		//struct type_cast : seq<type_id, parens> {};										// {type_id}{parens}		Int("4")
+		// Type Casts
+		//struct type_cast : seq<type_id, parens> {};									// {type_id}{parens}			Int("4")
 		struct type_cast : seq<cast, expr_0> {};										// ({type_id}){expr_0}			(Int)"4"
 		struct expr_tcast : sor<type_cast, expr_0> {};
 
 		// Operator '^'
 		struct ee_1 : if_must<op_1, seps, expr_tcast> {};								// ee_#'s structure the parsing to allow ast to be constructed left->right
-		struct expr_1 : seq<expr_tcast, star<seps, ee_1>, seps> {};						// {expr_0}( *{op_1} *{expr_0})* *
+		struct expr_1 : seq<expr_tcast, star<seps, ee_1>> {};							// {expr_0}( *{op_1} *{expr_0})*
 
-		// Operator '*', '/'
-		struct ee_2 : if_must<op_2, seps, expr_1> {};									// change name to left_assoc_# (or something similar)
-		struct expr_2 : seq<expr_1, star<seps, ee_2>, seps> {};							// {expr_1}( *{op_2} *{expr_1})* *
+																						// Operator '*', '/'
+		struct ee_2 : if_must<op_2, seps, expr_1> {};									// change name to left_assoc_# (or something similar) ???
+		struct expr_2 : seq<expr_1, star<seps, ee_2>> {};								// {expr_1}( *{op_2} *{expr_1})*
 
-		// Operator '+', '-'
+																						// Operator '+', '-'
 		struct ee_3 : if_must<op_3, seps, expr_2> {};
-		struct expr_3 : seq<expr_2, star<seps, ee_3>, seps> {};							// {expr_2}( *{op_3} *{expr_2})* *
+		struct expr_3 : seq<expr_2, star<seps, ee_3>> {};								// {expr_2}( *{op_3} *{expr_2})*
 
-		// Type Check and Boolean operators
+																						// Type Check and Boolean operators
 		struct ee_4 : if_must<op_4, seps, expr_3> {};
-		struct ee_tc : if_must<k_inherit, seps, type_id> {};
-		//struct expr_4 : seq<expr_3, opt<seps, sor<ee_tc, ee_4>>, seps> {};			// {expr_3}( *({<- *{type_id})|({op_4} *{expr_3})? *
-		struct expr_4 : seq<expr_3, star<seps, sor<ee_tc, ee_4>>, seps> {};				// {expr_3}( *({<- *{type_id})|({op_4} *{expr_3})* *
+		struct ee_tc : if_must<op_inherit, seps, type_id> {};
+		//struct expr_4 : seq<expr_3, opt<seps, sor<ee_tc, ee_4>>> {};					// {expr_3}( *({<- *{type_id})|({op_4} *{expr_3})?
+		struct expr_4 : seq<expr_3, star<seps, sor<ee_tc, ee_4>>> {};					// {expr_3}( *({<- *{type_id})|({op_4} *{expr_3})*
 
-		// Boolean and
-		struct ee_5 : seq<pad<k_and, sep>, expr_4> {};
-		struct expr_5 : seq<expr_4, opt<seps, ee_5>, seps> {};							// {expr_4}( *and *{expr_4})? *
+																						// Boolean and
+		struct ee_5 : if_must<k_and, seps, expr_4> {};
+		struct expr_5 : seq<expr_4, star<seps, ee_5>> {};								// {expr_4}( *and *{expr_4})?
 
-		// Boolean or
-		struct ee_6 : seq<pad<k_or, sep>, expr_5> {};
-		struct expr_6 : seq<expr_5, opt<seps, ee_6>, seps> {};							// {expr_5}( *or *{expr_5})? *
+																						// Boolean or
+		struct ee_6 : if_must<k_or, seps, expr_5> {};
+		struct expr_6 : seq<expr_5, star<seps, ee_6>> {};								// {expr_5}( *or *{expr_5})?
 
-		// Multiple Assignment
-		struct assign : seq<var_list, seps, op_x> {};									// assignments are right associative
-		struct ee_7 : seq<assign, seps, expr_list, seps> {};							// ensure that expr_6 doesn't trigger the expression reduction
-		struct expr_7 : if_then_else<at<assign>, ee_7, expr_6> {};						// {var_list} *{op_5} * {expr_list} *
+																						// Assignment (Right-associative)
+		struct assign : seq<var_list, seps, op_7> {};									// assignments are right associative
+		struct ee_7 : seq<assign, seps, expr_list> {};									// ensure that expr_6 doesn't trigger the expression reduction
+		struct expr_7 : if_then_else<at<assign>, ee_7, expr_6> {};						// {var_list} *{op_5} * {expr_list}
 
-		// Type Creation
-		struct ee_inherit : seq<seps, k_inherit, seps, type_id> {};
-		struct ee_type : seq<k_type, seps, type_id, seps, table, opt<ee_inherit>, seps> {};
-		struct expr_type : sor<ee_type, expr_7> {};										// type *{type_id} *{table}( *<- *{type_id})? *
+																						// Type Creation
+		struct ee_inherit : seq<seps, op_inherit, seps, type_id> {};
+		struct ee_type : seq<k_type, spaces, type_id, white, table, opt<ee_inherit>> {};
+		struct expr_type : sor<ee_type, expr_7> {};										// type[ ]*{type_id} *{table}( *<- *{type_id})?
 
 		// Try-Catch
-			// NOTE: THIS GRAMMAR DOESN'T WORK FOR DESCRIBING TRY-CATCH STATEMENTS
-		struct ee_try : seq<seps, expr> {};
-		struct ee_catch : seq<one<'('>, var_id, one<')'>, seps, expr> {};
-		struct ee_trycatch : if_must<k_try, ee_try, seps, k_catch, ee_catch> {};					// can't type try\n\t3\ncatch (problem with tables as well)
-		struct expr_trycatch : sor<ee_trycatch, expr_type> {};
+		// struct ee_try : seq<seps, expr> {};
+		// struct ee_catch : seq<one<'('>, var_id, one<')'>, seps, expr> {};
+		// struct ee_trycatch : if_must<k_try, ee_try, seps, k_catch, ee_catch> {};
+		// struct expr_trycatch : sor<ee_trycatch, expr_type> {};
+		struct expr_trycatch : expr_type {};				// unimplemented
+
+
+		struct expr_x : expr_trycatch {};
+		struct expr : expr_x {};
+
 
 		// Organization Tokens
-		struct expr_x : expr_trycatch {};
-		//struct expr_x : expr_type {};
-		struct expr : sor<seq<expr_x, seps, opt<comment>>, seq<seps, comment>> {};		// ({expr_x} *{comment}?| *{comment})
+		// line = \t*[ ]*{expr}? *{comment}?\n
 
-		// Defines Scoping rules
-			// REWORK
-		struct block {
-			using analyze_t = analysis::counted<analysis::rule_type::PLUS, 1, expr, block>;
+		struct line : seq<scope, pad<expr, tail>, opt<comment>, must<eolf>> {};		// fails on empty lines
+		//struct line : must<scope, sor<pad<expr, tail>, star<tail>>, opt<comment>, eolf> {};
+		//struct line : sor<seq<scope, pad<expr, tail>, opt<comment>, must<eolf>>, seq<star<tail>, opt<comment>, must<eolf>>> {};
+		//struct line : seq<scope, pad<opt<expr>, tail>, opt<comment>, must<eolf>> {};
 
-			template <apply_mode A, template<typename...> class Action, template<typename...> class Error>
-			static bool match(input& in, AST& ast, const int exit) {
-				int depth = -1;
-				ast.push(makeNode<Control>());															// Push sentinel node
-
-				// Parse until the scope depth decreases or the file ends
-				while (in.size() > 0 && (depth = block::depth(in)) >= exit) {
-					// If the scope depth increases, parse a new block
-					if (depth > exit)
-						Error<must<block>>::template match<A, Action, Error>(in, ast, exit + 1);		// Increment to depth in order to handle deep scoping (Needs optimizing for empty Blocks)
-
-					// Otherwise, parse an expression
-					else {
-						block::eat(in, depth);
-						Error<must<expr>>::template match<A, Action, Error>(in, ast, exit);
-						//Error<must<sor<expr, seps>>>::template match<A, Action, Error>(in, ast, exit);
-					}
-				}
-
-				return true;
-			}
-
-			// Determines the depth of the current line. Doesn't consume			Also assumes that scoping == '\t'
-			static int depth(const input& in) {
-				return in.string().find_first_not_of('\t');
-			}
-
-			// Consumes x scope layers from the input
-			static void eat(input& in, const int depth) {
-				in.bump(depth);					// Might need to rework depending on how scoping is syntax'd
-			}
-		};
-
-		// Allows the first line of a block to be in-lined (not used yet)
-			// I DON'T THINK THIS WORKS CORRECTLY
-		struct inline_block {
-			using analyze_t = block::analyze_t;
-
-			template <apply_mode A, template<typename...> class Action, template<typename...> class Control>
-			static bool match(input& in, AST& ast, const int scope) {
-				return Control<block>::template match<A, Action, Control>(in, ast, scope + 1);
-			}
-		};
-
-		struct file : block {};
-
+		struct file : star<line> {};								// Progress, but doesn't work
+																	//struct file : star<sor<line, until<eolf>>> {};			    // No progress, but works
 	}
 
-	// Grammar Token
-	struct grammar : pegtl::must<parse::file, pegtl::eolf> {};
+	struct grammar : pegtl::must<parse::file> {};
 }

--- a/Interpreter/Testing/Testing.cpp
+++ b/Interpreter/Testing/Testing.cpp
@@ -116,7 +116,7 @@ namespace dust {
 			t.initSubTest("Multiline Parsing");				// Need to escape output
 				t.requireEval("a\n+ b", 7);										// 1
 				t.requireException<pegtl::parse_error>("3 + a: 3\n - 4");		// 2
-				t.requireEval("3 + a 3\n - 4", -1);								// 3
+				t.requireEval("3 - \n 3", 0);									// 3
 				t.requireEval("3 + 3\n  \n4 + 4", 8);							// 4
 				t.requireEval("## Hello\n3", 3);								// 5
 
@@ -139,6 +139,10 @@ namespace dust {
 								   "\tb: 3 + .a\n"
 								   "## Assign b to 3 + a\n"
 								   "\tb + a", 7);								// 2
+					t.requireEval("3\n"
+								  "\t\ta: 5\n"
+								  "\t## Comment\n"
+								  "\t\ta + 1", 6);
 					t.requireEval("af: 3\n"
 								  "\t\t5\n"
 						          "\taf", 3);									// 3

--- a/Interpreter/Testing/Testing.cpp
+++ b/Interpreter/Testing/Testing.cpp
@@ -193,6 +193,25 @@ namespace dust {
 				t.requireEval("try 3 + true\n"
 							  "catch (e) 4", 4);
 
+				t.requireEval("try 3 + 3\n"
+							  "catch (e) 4", 6);
+
+				t.requireEval("a: 3\n"
+							  "try\n"
+							  "\t3 + true\n"
+							  "\t.a: 2\n"
+							  "catch (e)\n"
+							  "a", 3);
+
+				t.requireEval("a: 3\n"
+							  "try\n"
+							  "\t3 + 3\n"
+							  "\t.a: 2\n"
+							  "catch (e)\n"
+							  "a", 2);
+
+				t.requireException<error::missing_node_x>("catch (e) 4");
+
 			t.closeSubTest();
 
 			//t.initSubTest("API Testing");

--- a/Interpreter/Testing/Testing.cpp
+++ b/Interpreter/Testing/Testing.cpp
@@ -62,13 +62,19 @@ namespace dust {
 					t.requireEval("a, b:+ 2, 2", 2);							// 1
 					t.requireTrue("a = 5 and b = 2");							// 2
 
-					t.requireException<error::dispatch_error>("a, b:* 2");					// Invalid after Parser Rewrite v. II
-					t.requireTrue("a != 10");											// Invalid after Parser Rewrite v. II
-					t.requireEval("a, b:* 2, 0", 0);							// 3
-					t.requireTrue("a = 10 and b = 0");							// 4
+					t.requireException<error::dispatch_error>("a, b:* 2");		// 3
+					t.requireTrue("a = 10");									// 4
 
-					t.requireEval("a:= (b: 3) * 2 + 2 ^ 2", true);				// 5
-					t.requireTrue("a and b = 3");								// 6
+					t.requireException<error::dispatch_error>("a, b:* nil, 2");	// 5
+					t.requireTrue("a = 10");									// 6
+
+					t.eval("a, b: 5, 2");
+
+					t.requireEval("a, b:* 2, 0", 0);							// 7
+					t.requireTrue("a = 10 and b = 0");							// 8
+
+					t.requireEval("a:= (b: 3) * 2 + 2 ^ 2", true);				// 9
+					t.requireTrue("a and b = 3");								// 10
 				t.closeSubTest();
 			t.closeSubTest();
 
@@ -96,7 +102,7 @@ namespace dust {
 				t.requireTrue("a = 4");											// 2
 
 				t.requireException<pegtl::parse_error>("3 + a: 3");				// 3
-				t.requireException<error::missing_node_x>("a, b: 3, c: 4");		// 4
+				//t.requireException<error::missing_node_x>("a, b: 3, c: 4");		// 4
 
 				t.requireEval("a, b: 3, (c: 4)", 4);							// 5
 				t.requireTrue("a = 3");											// 6
@@ -178,6 +184,17 @@ namespace dust {
 				t.requireEval("a[b[2] * 2]", 5);
 
 			t.closeSubTest();
+
+			t.initSubTest("Try-Catch Statement");
+				t.requireEval("try\n"
+							  "\t3 + true\n"
+							  "catch (e) 4\n", 4);
+
+				t.requireEval("try 3 + true\n"
+							  "catch (e) 4", 4);
+
+			t.closeSubTest();
+
 			//t.initSubTest("API Testing");
 			//t.closeSubTest();
 

--- a/Interpreter/Testing/Testing.cpp
+++ b/Interpreter/Testing/Testing.cpp
@@ -139,6 +139,12 @@ namespace dust {
 								   "\tb: 3 + .a\n"
 								   "## Assign b to 3 + a\n"
 								   "\tb + a", 7);								// 2
+					t.requireEval("af: 3\n"
+								  "\t\t5\n"
+						          "\taf", 3);									// 3
+					t.requireEval("3\n"
+								  "## Comment\n"
+								  "4", 4);										// 4
 				t.closeSubTest();
 			t.closeSubTest();
 

--- a/Interpreter/Testing/Testing.cpp
+++ b/Interpreter/Testing/Testing.cpp
@@ -210,6 +210,11 @@ namespace dust {
 							  "catch (e)\n"
 							  "a", 2);
 
+				t.requireEval("try\n"
+							  "\t\t.a: 3 + 3\n"
+							  "\t3 + a\n"
+							  "catch(e)\n", 9);
+
 				t.requireException<error::missing_node_x>("catch (e) 4");
 
 			t.closeSubTest();

--- a/Interpreter/Testing/Testing.h
+++ b/Interpreter/Testing/Testing.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "Actions.h"
+#include "Control.h"
 
 #include "..\Exceptions\dust.h"
 #include "..\Exceptions\logic.h"
@@ -90,7 +90,7 @@ namespace dust {
 				// Construct and evaluate the AST for the given code segment
 				void evaluate(const std::string& code) {
 					parse::ScopeTracker scp{};
-					pegtl::parse<grammar, action>(parse::trim(code), code, tree, scp);
+					pegtl::parse<grammar, action, parse::control>(code, code, tree, scp);
 					tree.pop()->eval(e);
 				}
 

--- a/Interpreter/Testing/Testing.h
+++ b/Interpreter/Testing/Testing.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "Actions.h"
+
 #include "..\Exceptions\dust.h"
 #include "..\Exceptions\logic.h"
 #include "..\Exceptions\runtime.h"
@@ -88,7 +89,8 @@ namespace dust {
 
 				// Construct and evaluate the AST for the given code segment
 				void evaluate(const std::string& code) {
-					pegtl::parse<grammar, action>(parse::trim(code), code, tree, 0);
+					parse::ScopeTracker scp{};
+					pegtl::parse<grammar, action>(parse::trim(code), code, tree, scp);
 					tree.pop()->eval(e);
 				}
 

--- a/Interpreter/stack.h
+++ b/Interpreter/stack.h
@@ -23,17 +23,21 @@ namespace dust {
 				return idx < 0 || idx >(int)s.size();
 			}
 
-			virtual void before(Value& v, int bef) {
+			virtual void before(const Value& v, int bef) {
 				s.insert(s.begin() + normalize(bef), v);
 			}
 
-			virtual void after(Value& v, int bef) {
+			virtual void after(const Value& v, int bef) {
 				s.insert(s.begin() + normalize(bef) + 1, v);
 			}
 
 		public:
 			Stack() {
 				reserve(MIN_STACK_SIZE);
+			}
+
+			virtual void push(const Value& v) {
+				s.push_back(v);
 			}
 
 			virtual void push(Value& v) {

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# The Dust Programming Language (v 0.6.1)
+# The Dust Programming Language (v 0.6.5)
 	
 Dust is the working title for a multi-paradigm, expression-based, interpreted programming language. The development and design of Dust is largely intended as a hobby project that would explore how
 programming languages are designed and implemented by growing and nurturing the small seed that has sat in my mind for a couple of years into a fully-featured language. It is not intended to be a

--- a/ToDo.txt
+++ b/ToDo.txt
@@ -65,21 +65,26 @@ Timeline
 			Change 0 => false ???
 		See VagueToDo.txt
 				
-	2 Parser Rewrite v. II
-		Implement true try-catch statement (testing scoping composability)
-			Combining the try/catch blocks into the TryCatch statement is performed in action<scope>
-				Need to add "isFull" member to TryCatch to prevent some unwanted reduces
+	1 Parser Rewrite v. II
 		Add location information to ASTNodes at node construction
 			Need to rework makeNode and ASTNode constructors
 		Improve Exception Support
 			Improve error messages for try-catch construction
 
-	3 Control Statements (For/While/Do-While/If/Else/...)
+	2 Control Statements
 		Update project version to 0.7.1
-		Be able to write control statements with correct execution
-			Have variable scoping work correctly
+		Allow control strutures to "assign" variables
+			Test on Try-Catch statements (using the error message)
+		Implement loops (While/Do-While)
+			Have the grammar recognize them
+			Have the interpreter work on them
+		Implement Branching (If-Then-Else)
+			Have the grammar recognize them
+				Generalize Try-Catch combination in action<scope>::reduce
+			Have the interpreter work on them
+		Implement For statement
 
-	4 Function Calling		ie. print("Hello, World!")
+	3 Function Calling		ie. print("Hello, World!")
 		Implement the evaluation hooks/etc. to be able to call functions	# Get functions callable
 			Hard coded translations at this time
 			Have the basic syntax and semantics working (Argument passing, etc.)
@@ -93,18 +98,18 @@ Timeline
 		Move function calling work into the _op() metamethod
 		Optional: No parens syntax
 
-	5 Dust Function Definition
+	4 Dust Function Definition
 		Update project version to 0.8.1
 		Abstract the previous framework to allow for Dust functions to be conceivably executed
 		Add in the correct syntax and action calls to create dust functions
 
-	6 Grammar Framework Update
+	5 Grammar Framework Update
 		Potentially change the grammar to follow the basic framework in "lua53_parse.h"
 		Update all documents to ensure that they reflect the current language spec
 		Update the readme to show of recent aditions
 		Determine the next set of features that need to be implemented
 
-	7 Type/Table metamethods
+	6 Type/Table metamethods
 
 
 

--- a/ToDo.txt
+++ b/ToDo.txt
@@ -42,42 +42,48 @@ Timeline
 			Currently tables are references (ie. pointers)
 				This is passable but not what I want from the language
 		Redo how get/set are handled (in relation to exception throwing)
+			Ensure that EvalState::setVar static typing works correctly (I think it's currently bidirectional, should be unidirectional)
 		Check on changing ts.convertible(t1, t2) to ts.convertible(f, t)
 			Basically stopping convertible(a, b) = convertible(b, a) from always being true
-			Where did I want to change this from
+			Where did I want to change this from (EvalState::setVar)
 		Implement Table::okayKey and Table::okayValue and provide a way to change behavior
 			These methods are how "3: 3" will be prevented in the global scope and allowed in tables
 			Also allow for restricting key and values based on given functions
-		Implement Console manipulators for mac and windows
+		Implement Console manipulators for mac and linux
 			Apparently both use ansi color codes
 		Clean up the code for the testing framework
-		See VagueToDo.txt
-
-	1 Interpreter Update
-		Fix some bugs/improvements
-			Change 0 => false (Find out what documents/files to change)
-			Check EvalState::setVar static typing conversion handling (I don't think it'll work, wrong direction)
+		Unsure about behavior of action<c_paren> for empty parentheses
 		Start reading up on the gsl
+			Try converting some code once I understand it
+		Various Changes
+			Change 0 => false ???
+		See VagueToDo.txt
 				
 	2 Parser Rewrite v. II
-		Redo how scoping is handled by the parser
-			Add a "scoping" rule at the beginning of expr
-				This scoping rule will work similar to Python (need a "scope" stack?)
-				Block gets deleted from the grammar
-					Means I can't completely describe everything in the grammar as a single expression
-						Should still parse that way though
-				The grammar rule just matches any number of "scope" characters
-					The action will handle the control push/popping (allows custom control structures for loops/branches/etc.)
+		Parser Rewrite
+			Still need to rework line to have correct parsing of comments and empty lines
+			Fix errors with new approach (Failing some new tests)
+				Basics.4		## Attempt to index container of size 0
+				Basics.5		## Attempt to index container of size 0
+				Basics.8		## ".3" did not throw an exception
+				Mutliline.2		## parse error matching struct eolf
+				Multiline.3		## Result of 6 did not match expected value of 8
+				Multiline.4		## Couldn't convert to Int in Traits<int>::get
+				Comments.0		## parse error matching struct eolf
+				Comments.1		## Attempt to index container of size 0
+				Comments.3		## Result of 3 did not match expected value of 4
 			Try to simplify the grammar if possible
-		Fix Grammar so that Testing.99 throws an error at parse time (not at runtime) ???
+				Determine where whitespace should be required/restricted
+			Ensure that everything works well together
+		Implement true try-catch statements
+		Fix Grammar so that Testing:line 99 throws an error at parse time (not at runtime) ???
 			Or should I (it would certainly be extremely difficult to debug)
 				Assignment => value which can be used in another assignment
+		Add in location information to ASTNodes
 		Improve Exception Support
-		Try converting some code to make use of the gsl
 		Rework Assignment to be performed left->right
 			Changes "a, b:* 3" to multiply a by 3 (before excepting on the 3)
 				Stops "a, b:* nil, 3" from multiplying b by 3
-		Rewrite the parser so that everything works well together
 
 	3 Control Statements (For/While/Do-While/If/Else/...)
 		Update project version to 0.7.1

--- a/ToDo.txt
+++ b/ToDo.txt
@@ -63,9 +63,7 @@ Timeline
 		Parser Rewrite
 			Still need to rework line to have correct parsing of comments and empty lines
 			Fix errors with new approach (Failing some new tests)
-				Basics.4		## Attempt to index container of size 0
-				Basics.5		## Attempt to index container of size 0
-				Basics.8		## ".3" did not throw an exception
+				Basics.8		## Fixed (Fix not implemented)x
 				Mutliline.2		## parse error matching struct eolf
 				Multiline.3		## Result of 6 did not match expected value of 8
 				Multiline.4		## Couldn't convert to Int in Traits<int>::get
@@ -74,6 +72,8 @@ Timeline
 				Comments.3		## Result of 3 did not match expected value of 4
 			Try to simplify the grammar if possible
 				Determine where whitespace should be required/restricted
+			Add in Control declarations
+				bad_decimal to throw an error on successful match
 			Ensure that everything works well together
 		Implement true try-catch statements
 		Fix Grammar so that Testing:line 99 throws an error at parse time (not at runtime) ???

--- a/ToDo.txt
+++ b/ToDo.txt
@@ -48,6 +48,7 @@ Timeline
 			Where did I want to change this from (EvalState::setVar)
 		Implement Table::okayKey and Table::okayValue and provide a way to change behavior
 			These methods are how "3: 3" will be prevented in the global scope and allowed in tables
+				Change the expected exception on Testing:line 99 once implemented
 			Also allow for restricting key and values based on given functions
 		Implement Console manipulators for mac and linux
 			Apparently both use ansi color codes
@@ -65,19 +66,13 @@ Timeline
 		See VagueToDo.txt
 				
 	2 Parser Rewrite v. II
-		Parser Rewrite
-			Try to simplify the grammar if possible
-				Determine where whitespace should be required/restricted
-			Ensure that everything works well together
-		Implement true try-catch statements
-		Fix Grammar so that Testing:line 99 throws an error at parse time (not at runtime) ???
-			Or should I (it would certainly be extremely difficult to debug)
-				Assignment => value which can be used in another assignment
-		Add in location information to ASTNodes
+		Implement true try-catch statement (testing scoping composability)
+			Combining the try/catch blocks into the TryCatch statement is performed in action<scope>
+				Need to add "isFull" member to TryCatch to prevent some unwanted reduces
+		Add location information to ASTNodes at node construction
+			Need to rework makeNode and ASTNode constructors
 		Improve Exception Support
-		Rework Assignment to be performed left->right
-			Changes "a, b:* 3" to multiply a by 3 (before excepting on the 3)
-				Stops "a, b:* nil, 3" from multiplying b by 3
+			Improve error messages for try-catch construction
 
 	3 Control Statements (For/While/Do-While/If/Else/...)
 		Update project version to 0.7.1

--- a/ToDo.txt
+++ b/ToDo.txt
@@ -52,7 +52,12 @@ Timeline
 		Implement Console manipulators for mac and linux
 			Apparently both use ansi color codes
 		Clean up the code for the testing framework
-		Unsure about behavior of action<c_paren> for empty parentheses
+		Parser Issues
+			Unsure about behavior of action<c_paren> for empty parentheses
+			Speed up the performance of parsing line
+				Currently has to read eval_line twice to ensure correctness
+			Minimize the cost of specializing Control (too many declarations)
+				Check the documentation first, I might be missing something there
 		Start reading up on the gsl
 			Try converting some code once I understand it
 		Various Changes
@@ -61,19 +66,8 @@ Timeline
 				
 	2 Parser Rewrite v. II
 		Parser Rewrite
-			Still need to rework line to have correct parsing of comments and empty lines
-			Fix errors with new approach (Failing some new tests)
-				Basics.8		## Fixed (Fix not implemented)x
-				Mutliline.2		## parse error matching struct eolf
-				Multiline.3		## Result of 6 did not match expected value of 8
-				Multiline.4		## Couldn't convert to Int in Traits<int>::get
-				Comments.0		## parse error matching struct eolf
-				Comments.1		## Attempt to index container of size 0
-				Comments.3		## Result of 3 did not match expected value of 4
 			Try to simplify the grammar if possible
 				Determine where whitespace should be required/restricted
-			Add in Control declarations
-				bad_decimal to throw an error on successful match
 			Ensure that everything works well together
 		Implement true try-catch statements
 		Fix Grammar so that Testing:line 99 throws an error at parse time (not at runtime) ???

--- a/ToDo.txt
+++ b/ToDo.txt
@@ -66,49 +66,52 @@ Timeline
 			Change 0 => false ???
 		See VagueToDo.txt
 				
-	1 Parser Rewrite v. II
-		Improve Exception Support
-			Improve error messages for try-catch construction
-
-	2 Control Statements
+	1 Control Statements
 		Update project version to 0.7.1
 		Allow control strutures to "assign" variables
 			Test on Try-Catch statements (using the error message)
 		Implement loops (While/Do-While)
 			Have the grammar recognize them
 			Have the interpreter work on them
-		Implement Branching (If-Then-Else)
+		Implement Branching (If-Elseif-Else)
+			I could always move to "else if" instead of "elseif"
 			Have the grammar recognize them
 				Generalize Try-Catch combination in action<scope>::reduce
 			Have the interpreter work on them
 		Implement For statement
 
-	3 Function Calling		ie. print("Hello, World!")
+	2 Function Calling		ie. print("Hello, World!")
+		Be able to store functions as values
+			Create the necessary Collector structure (needs to handle C++ functions/lambdas and dust AST's)
+			Get assignment to work as expected with functions
 		Implement the evaluation hooks/etc. to be able to call functions	# Get functions callable
 			Hard coded translations at this time
 			Have the basic syntax and semantics working (Argument passing, etc.)
-		Be able to store functions as values
-			Get assignment to work as expected with functions
 		Convert Types completely to impl::Table for storage concerns
-			Allow Type methods to be called using '.'/'[]' syntax
-				Current grammar disallows type_ids to be used outside of new_type and type_checking
 			Allow Type methods to be called using '.'/'[]' syntax on non-table values and variables
 				Current AST construction assumes a VarName node exists (not guaranteed for non-variables)
+			Allow Type methods to be called using '.'/'[]' syntax
+				Current grammar disallows type_ids to be used outside of new_type and type_checking
 		Move function calling work into the _op() metamethod
+			_op() expects a l->r stack (function on top, first argument at -2, etc.)
+			Push arguments from r->l on the stack
+			Get function value on the stack
+			Call _op() on the function
 		Optional: No parens syntax
 
-	4 Dust Function Definition
+	3 Dust Function Definition
 		Update project version to 0.8.1
 		Abstract the previous framework to allow for Dust functions to be conceivably executed
 		Add in the correct syntax and action calls to create dust functions
 
-	5 Grammar Framework Update
+	4 Grammar Framework Update
 		Potentially change the grammar to follow the basic framework in "lua53_parse.h"
 		Update all documents to ensure that they reflect the current language spec
 		Update the readme to show of recent aditions
 		Determine the next set of features that need to be implemented
+		Bugfixes
 
-	6 Type/Table metamethods
+	5 Type/Table metamethods
 
 
 

--- a/ToDo.txt
+++ b/ToDo.txt
@@ -59,6 +59,7 @@ Timeline
 				Currently has to read eval_line twice to ensure correctness
 			Minimize the cost of specializing Control (too many declarations)
 				Check the documentation first, I might be missing something there
+			Consider rearranging/repurposing actions to provide better parser data
 		Start reading up on the gsl
 			Try converting some code once I understand it
 		Various Changes
@@ -66,8 +67,6 @@ Timeline
 		See VagueToDo.txt
 				
 	1 Parser Rewrite v. II
-		Add location information to ASTNodes at node construction
-			Need to rework makeNode and ASTNode constructors
 		Improve Exception Support
 			Improve error messages for try-catch construction
 

--- a/main.cpp
+++ b/main.cpp
@@ -9,8 +9,6 @@
 #define pl(x) p(x) << "\n"
 #define nl() pl("")
 
-// TODO:		
-// Update the PEGTL library if possible
 
 // Things to work on
 	// Improving and consolidating the API
@@ -51,25 +49,29 @@ int main(int argc, const char* argv[]) {
 
 	parse::AST parse_tree;
 	std::string input;
+
 	EvalState e;
+	parse::ScopeTracker scp{};
 
 	initState(e);
 	test::runTests(e, show_all_tests);
 
-	std::cout << "> ";
+	std::cout << "\n> ";
 
 	while (getmultiline(std::cin, input) && input != "exit") {
 		if (input == "gc") {
 
 		} else {
 			try {
-				//pegtl::parse<grammar, action>(parse::trim(input), input, parse_tree, 0);
-				pegtl::parse<grammar, action, parse::control>(parse::trim(input), input, parse_tree, 0);
+				pegtl::parse<grammar, action, parse::control>(input, input, parse_tree, scp);
+				//pegtl::parse<grammar, action, parse::control>(parse::trim(input), input, parse_tree, scp);
 
-				printAST(std::cout, parse_tree.at());
+				// This allows "3 # Hello" to run (should throw an error)
+				if (!parse_tree.empty()) {
+					printAST(std::cout, parse_tree.at());
 
-
-				parse_tree.pop()->eval(e).stream(std::cout << ":: ") << "\n";
+					parse_tree.pop()->eval(e).stream(std::cout << ":: ") << "\n";
+				}
 				//e.eval(parse_tree.pop()).stream(std::cout << ":: ") << "\n";
 
 				// Need to make a generic 'pop' here

--- a/main.cpp
+++ b/main.cpp
@@ -51,7 +51,6 @@ int main(int argc, const char* argv[]) {
 	std::string input;
 
 	EvalState e;
-	parse::ScopeTracker scp{};
 
 	initState(e);
 	test::runTests(e, show_all_tests);
@@ -63,6 +62,8 @@ int main(int argc, const char* argv[]) {
 
 		} else {
 			try {
+				parse::ScopeTracker scp{};
+
 				pegtl::parse<grammar, action, parse::control>(input, input, parse_tree, scp);
 				//pegtl::parse<grammar, action, parse::control>(parse::trim(input), input, parse_tree, scp);
 


### PR DESCRIPTION
Rewrote the way scoping is handled by the parser and the grammar
Implemented correct TryCatch grammar
Changed assignment to be performed left->right (values are still evaluated before the assignments)
